### PR TITLE
Fix posts update on tag select

### DIFF
--- a/src/app/custom-pages/tag-archive/tag-archive.component.html
+++ b/src/app/custom-pages/tag-archive/tag-archive.component.html
@@ -1,5 +1,5 @@
 <h1>Posts for Tag: <span class="text-indigo-800">{{tag}}</span></h1>
 
-<app-post-box *ngFor="let post of posts"
+<app-post-box *ngFor="let post of posts$ | async"
                 [highlightedTag]="tag"
                 [post]="post"></app-post-box>

--- a/src/app/custom-pages/tag-archive/tag-archive.component.ts
+++ b/src/app/custom-pages/tag-archive/tag-archive.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { PostService } from 'src/app/services/post.service';
 import Post from 'src/app/models/post';
 import {PageHeadService} from "../../services/page-head.service";
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-tag-archive',
@@ -10,16 +11,16 @@ import {PageHeadService} from "../../services/page-head.service";
 })
 export class TagArchiveComponent implements OnInit {
   tag: string;
-  posts: Post[];
+  posts$: Observable<Post[]>;
 
   constructor(private route: ActivatedRoute, private postService: PostService, private pageHeadService: PageHeadService) { }
 
   ngOnInit(): void {
     this.route.params.subscribe(params => {
       this.tag = params.tag;
+      this.posts$ = this.postService.getPostsForTag(this.tag);
     });
 
-    this.postService.getPostsForTag(this.tag).subscribe(posts => this.posts = posts);
     this.pageHeadService.setTitle("Tags");
   }
 


### PR DESCRIPTION
This PR fixes issue #4.

The **getPostsForTag** method just needed to be called again when the route param changed :)

Also took the liberty to change the property to be a async pipe instead of a manual subscription. It's a good practice since Angular automatically unsubscribes to the observable when the component is destroyed.